### PR TITLE
MLPR-159 - make extension compatible with Laravel 9 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "laravel/framework": "^6|^7|^8",
+        "laravel/framework": "^6|^7|^8|^9",
         "guzzlehttp/guzzle": "~7.0"
     },
     "extra": {

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ With this integration you could use some Laravel's feature that allows to handle
 - `Auth::guest()`: returns `true` if a user is guest, `false` otherwise
 - `Auth::user()`: returns a `ZUser` class instance, `null` otherwise
 - `Auth::id()`: returns `userId` if authtenticated, `null` otherwise
+- `Auth::hasUser()`: returns `true` if there's a ZUser in our current session, `false` otherwise
 - `Auth::setUser($ZUser)`: sets a `Zuser` in session
 - `Auth::attempt($credentials, $remember)`: try to login with IDP without using the login form, if success returns `true`, otherwise `false`
 - `Auth::logout()`: logout a user, return `redirect`

--- a/src/Guards/ZGuard.php
+++ b/src/Guards/ZGuard.php
@@ -107,6 +107,16 @@ class ZGuard implements Guard, StatefulGuard
     }
 
     /**
+     * Determine if the guard has a user instance.
+     *
+     * @return bool
+     */
+    public function hasUser()
+    {
+        return $this->session->get('user') ? true : false;
+    }
+
+    /**
      * Set the current user.
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable $user

--- a/src/Guards/ZGuard.php
+++ b/src/Guards/ZGuard.php
@@ -113,7 +113,7 @@ class ZGuard implements Guard, StatefulGuard
      */
     public function hasUser()
     {
-        return $this->session->get('user') ? true : false;
+        return $this->session->exists('user');
     }
 
     /**


### PR DESCRIPTION
**Make extension compatible with Laravel 9:**

To ensure compatibility with the new version of Laravel, this Pr adds ^9 dependency option for the laravel framework in composer.json and implements a new interface method in ZGuard.

**Motivation and Context**
Team Booktab is developing a new project using Laravel 9 and the extension wasn't compatible.

**Priority**

 - [ ] 1 - Highest
 - [ ]  2 - High
 - [x]  3 - Medium
 - [ ]  4 - Low
 - [ ]  5 - Lowest
 - [ ]  6 - Not a Priority

Types of changes

 - [ ] Bugfix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Component (add a Component as approved by Design System)
 - [ ] Docs (add documentation)
 - [x] Chore (changes that adds small enhancement)
 - [ ] Breaking (fix or feature that would cause existing functionality to not work as expected)