### PR TITLE
IDP-235: fix use locally and handle response

### DIFF
--- a/src/Http/Middleware/IdpApiMiddleware.php
+++ b/src/Http/Middleware/IdpApiMiddleware.php
@@ -9,13 +9,14 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Zanichelli\IdpExtension\Models\ZTrait\ZUserBuilder;
 
-class AddIdpUserDataMiddleware
+class IdpApiMiddleware
 {
     use ZUserBuilder;
 
     public function handle(Request $request, Closure $next)
     {
-        $token = $request->input('token')? $request->input('token') : $request->cookies->get(config("idp.cookie.name"));
+        $token = $request->input('token') ?? $request->cookies->get(config("idp.cookie.name"));
+
         if ($token) {
             try {
                 $client = new Client(['verify' => false]);
@@ -31,7 +32,6 @@ class AddIdpUserDataMiddleware
             } catch (Exception $e) {
                 Log::error($e->getMessage());
                 return response()->json([], 401);
-
             }
         } else {
             return response()->json([], 401);

--- a/src/Http/Middleware/IdpApiMiddleware.php
+++ b/src/Http/Middleware/IdpApiMiddleware.php
@@ -15,7 +15,7 @@ class AddIdpUserDataMiddleware
 
     public function handle(Request $request, Closure $next)
     {
-        $token = $request->cookies->get(config("idp.cookie.name"));
+        $token = $request->input('token')? $request->input('token') : $request->cookies->get(config("idp.cookie.name"));
         if ($token) {
             try {
                 $client = new Client(['verify' => false]);
@@ -30,8 +30,11 @@ class AddIdpUserDataMiddleware
                 $request->merge(['user' => $user]);
             } catch (Exception $e) {
                 Log::error($e->getMessage());
-                return response()->json(['message' => $e->getMessage()], $e->getCode());
+                return response()->json([], 401);
+
             }
+        } else {
+            return response()->json([], 401);
         }
 
         return $next($request);


### PR DESCRIPTION
$request->input('token')? $request->input('token') -> serve per poter usare il middleware anche da locale (in locale il cookie non viene mai trovato)

return response()->json(['message' => $e->getMessage()], $e->getCode()); -> faceva si che nelle nostre API sarebbe stato da docummentare e sarebbe possibilile ricevere tutte le risposte che ritorna idp... 

Cambiato il nome file per esprimere meglio che quel middleware è pensato solo per le API (perchè non ritorniamo mai il redirect ma solo il 401)